### PR TITLE
Exposed 3483/udp for server autodiscovery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN ln -s /usr/bin/flac /usr/share/squeezeboxserver/Bin/x86_64-linux/
 RUN ln -s /usr/bin/sox /usr/share/squeezeboxserver/Bin/x86_64-linux/
 
 VOLUME $SQUEEZE_VOL
-EXPOSE 3483 9000 9090
+EXPOSE 3483 3483/udp 9000 9090
 
 COPY entrypoint.sh /entrypoint.sh
 COPY start-squeezebox.sh /start-squeezebox.sh


### PR DESCRIPTION
This enables the possibility for serverautodiscovery from squeezebox radio.
expose the udp port by running
docker run -d \
           -p 9000:9000 \
           -p 3483:3483 \
           -p 3483:3483/udp \
           -v <local-state-dir>:/srv/squeezebox \
           -v <audio-dir>:/srv/music \
           larsks/logitech/media-server