### PR TITLE
Run as user squeezeboxserver

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,8 +3,9 @@
 if [ "$SQUEEZE_VOL" ] && [ -d "$SQUEEZE_VOL" ]; then
 	for subdir in prefs logs cache; do
 		mkdir -p $SQUEEZE_VOL/$subdir
+		chown -R squeezeboxserver:nogroup $SQUEEZE_VOL/$subdir
 	done
 fi
 
-exec /start-squeezebox.sh "$@"
+exec sudo -u squeezeboxserver -E /start-squeezebox.sh "$@"
 

--- a/start-squeezebox.sh
+++ b/start-squeezebox.sh
@@ -8,7 +8,7 @@ echo "$url"
 echo ======================================================================
 echo
 
-exec squeezeboxserver --user root \
+exec squeezeboxserver \
 	--prefsdir $SQUEEZE_VOL/prefs \
 	--logdir $SQUEEZE_VOL/logs \
 	--cachedir $SQUEEZE_VOL/cache "$@"


### PR DESCRIPTION
Running LMS as root is discouraged both by the LMS developers and docker best practices.

The --user switch of squeezeboxserver doesn't work well for our purpose since it created the LMS logs as root and later bails because it can't write to them (after giving up root). 