### PR TITLE
Include SSL support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV PACKAGE_VERSION_URL=http://www.mysqueezebox.com/update/?version=7.9.0&revision=1&geturl=1&os=deb
 
 RUN apt-get update && \
-	apt-get -y --force-yes install curl wget faad flac lame sox && \
+	apt-get -y --force-yes install curl wget faad flac lame sox libio-socket-ssl-perl && \
 	url=$(curl "$PACKAGE_VERSION_URL" | sed 's/_all\.deb/_amd64\.deb/') && \
 	curl -Lsf -o /tmp/logitechmediaserver.deb $url && \
 	dpkg -i /tmp/logitechmediaserver.deb && \


### PR DESCRIPTION
Gets rid the this error message:
```
Async::HTTP: Unable to load IO::Socket::SSL, will try connecting to SSL servers in non-SSL mode
```