### PR TITLE
Feature/raspberry cross build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 .env
+qemu-aarch64-static
+qemu-arm-static
+qemu-x86_64-static
+Dockerfile.amd64
+Dockerfile.arm32v7
+Dockerfile.arm64v8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+sudo: required
+
+language: bash
+
+services:
+  - docker
+
+before_install:
+  - sudo service docker stop
+  - curl -fsSL https://get.docker.com/  | sudo sh
+  - docker run --rm --privileged multiarch/qemu-user-static:register --reset
+  - ./prepare.sh
+
+script:
+   - ./build.sh

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,5 +1,7 @@
-FROM ubuntu:xenial
+FROM __BASEIMAGE_ARCH__/ubuntu:xenial
 MAINTAINER Lars Kellogg-Stedman <lars@oddbit.com>
+
+__CROSS_COPY qemu-__QEMU_ARCH__-static /usr/bin/
 
 ENV SQUEEZE_VOL /srv/squeezebox
 ENV LANG C.UTF-8
@@ -19,7 +21,7 @@ RUN apt-get update && \
 		&& \
 	apt-get clean
 
-RUN url=$(curl "$PACKAGE_VERSION_URL" | sed 's/_all\.deb/_amd64\.deb/') && \
+RUN url=$(curl "$PACKAGE_VERSION_URL") && \
 	curl -Lsf -o /tmp/logitechmediaserver.deb $url && \
 	dpkg -i /tmp/logitechmediaserver.deb && \
 	rm -f /tmp/logitechmediaserver.deb && \

--- a/README.md
+++ b/README.md
@@ -38,3 +38,37 @@ for example:
     AUDIO_DIR=/home/USERNAME/Music
 
 [docker-compose.yaml]: docker-compose.yaml
+
+## Image building process
+
+### Register QEMU binfmt_misc handlers
+
+Register `qemu-*-static` for all supported processors (except the current one) as `binfmt_misc` handlers. You only need to do this once.
+
+```
+docker run --rm --privileged multiarch/qemu-user-static:register
+```
+
+In case you get an error message, try again with first removing all registered `binfmt_misc` handlers.
+
+```
+docker run --rm --privileged multiarch/qemu-user-static:register --reset
+```
+
+### Prepare Build
+To prepare the build download the required QEMU static user binaries.
+
+```
+./prepare.sh
+```
+
+### Build Docker images
+Docker images for all supported platforms are built one after the other.
+
+```
+./build.sh
+```
+
+### References
+- [HomeOps - Building multi-arch docker images](https://lobradov.github.io/Building-docker-multiarch-images/)
+- [How to Build ARM Docker Images on Intel host](http://www.hotblackrobotics.com/en/blog/2018/01/22/docker-images-arm/)

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+DOCKER_REPO=toertel
+DOCKER_IMAGE=logitech-media-server
+DOCKER_ARCHS="amd64 arm32v7 arm64v8"
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+for docker_arch in ${DOCKER_ARCHS}; do
+  case ${docker_arch} in
+    amd64       ) qemu_arch="x86_64" ;;
+    arm32v[5-7] ) qemu_arch="arm" ;;
+    arm64v8     ) qemu_arch="aarch64" ;;
+    *           )
+      echo ERROR: Unsupported architecture \'"${docker_arch}"\'
+      exit 1
+  esac
+
+  # Instantiate templates and fill in variables
+  cp Dockerfile.template "Dockerfile.${docker_arch}"
+  sed -i "s/__BASEIMAGE_ARCH__/${docker_arch}/g" "Dockerfile.${docker_arch}"
+  sed -i "s/__QEMU_ARCH__/${qemu_arch}/g" "Dockerfile.${docker_arch}"
+
+  if [ "${docker_arch}" = 'amd64' ]; then
+    # Remove __CROSS_ commands for amd64 (native) builds
+    sed -i "/__CROSS_/d" "Dockerfile.${docker_arch}"
+  else
+    # Activate __CROSS_ commands for cross builds
+    sed -i "s/__CROSS_//g" "Dockerfile.${docker_arch}"
+  fi
+
+  docker build -f "Dockerfile.${docker_arch}" -t "${DOCKER_REPO}/${DOCKER_IMAGE}:${docker_arch}-latest" .
+done

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+QEMU_VERSION=v3.1.0-2
+QEMU_ARCHS="x86_64 arm aarch64"
+
+TMPDIR=$(mktemp -d -t qemu-static_XXXX)
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+cleanup () {
+    rm -rf "${TMPDIR}"
+}
+
+trap cleanup EXIT
+
+for target_arch in ${QEMU_ARCHS}; do
+  wget -N -P "${TMPDIR}" "https://github.com/multiarch/qemu-user-static/releases/download/${QEMU_VERSION}/x86_64_qemu-${target_arch}-static.tar.gz"
+  tar -xvf "${TMPDIR}/x86_64_qemu-${target_arch}-static.tar.gz"
+done


### PR DESCRIPTION
I am running your LMS image on a Raspberry Pi. Until now I had to build the image natively on the RPi and that took a long time. These patches make it possible to cross-build ARM images on x86/amd64 PCs.

So far only a single architecture image is built. But Docker now also supports multi-architecture images. This could be the next step.